### PR TITLE
INT-9043 changes to homebrew to support arm and intel for IQ CLI

### DIFF
--- a/Casks/nexus-iq-cli.rb
+++ b/Casks/nexus-iq-cli.rb
@@ -5,12 +5,12 @@
 #
 
 cask "nexus-iq-cli" do
-  arch arm: "aarch64", intel: "fakeSha256Intel"
-  pkg_name = on_arch_conditional arm: "aarch_64", intel: "fakeSha256Intel"
+  arch arm: "aarch64", intel: "x86_64"
+  pkg_name = on_arch_conditional arm: "aarch_64", intel: "x86_64"
 
   version "2.2.0-01"
-  sha256 arm:   "fakeSha256Arm",
-         intel: "fakeSha256Intel"
+  sha256 arm:   "244bf5552da870634116c4b243f03b027de255bd6d91192335399f077fe4c9ce",
+         intel: "87587dfc303d317ec4d1af27f0c78f3829c56899bc765ea15aca2fc55eeeef31"
 
   url "https://download.sonatype.com/clm/scanner/nexus-iq-cli-#{version}-osx-#{pkg_name}.pkg"
 

--- a/Casks/nexus-iq-cli.rb
+++ b/Casks/nexus-iq-cli.rb
@@ -8,9 +8,8 @@ cask "nexus-iq-cli" do
   arch arm: "aarch64", intel: "x86_64"
   pkg_name = on_arch_conditional arm: "aarch_64", intel: "x86_64"
 
-  version "1.1.0-00"
-  sha256 arm:   "244bf5552da870634116c4b243f03b027de255bd6d91192335399f077fe4c9ce",
-         intel: "87587dfc303d317ec4d1af27f0c78f3829c56899bc765ea15aca2fc55eeeef31"
+  version "2.2.0-01"
+  sha256 arm:   ".+",n         intel: "fakeSha256Intel"
 
   url "https://download.sonatype.com/clm/scanner/nexus-iq-cli-#{version}-osx-#{pkg_name}.pkg"
 

--- a/Casks/nexus-iq-cli.rb
+++ b/Casks/nexus-iq-cli.rb
@@ -8,8 +8,8 @@ cask "nexus-iq-cli" do
   arch arm: "aarch64", intel: "x86_64"
   pkg_name = on_arch_conditional arm: "aarch_64", intel: "x86_64"
 
-  version "2.2.0-01"
-  sha256 arm:   "fakeSha256Arm",
+  version "1.1.0-00"
+  sha256 arm:   "244bf5552da870634116c4b243f03b027de255bd6d91192335399f077fe4c9ce",
          intel: "87587dfc303d317ec4d1af27f0c78f3829c56899bc765ea15aca2fc55eeeef31"
 
   url "https://download.sonatype.com/clm/scanner/nexus-iq-cli-#{version}-osx-#{pkg_name}.pkg"

--- a/Casks/nexus-iq-cli.rb
+++ b/Casks/nexus-iq-cli.rb
@@ -8,8 +8,9 @@ cask "nexus-iq-cli" do
   arch arm: "aarch64", intel: "x86_64"
   pkg_name = on_arch_conditional arm: "aarch_64", intel: "x86_64"
 
-  version "2.2.0-01"
-  sha256 arm:   ".+",n         intel: "fakeSha256Intel"
+  version "1.1.0-00"
+  sha256 arm:   "244bf5552da870634116c4b243f03b027de255bd6d91192335399f077fe4c9ce",
+         intel: "87587dfc303d317ec4d1af27f0c78f3829c56899bc765ea15aca2fc55eeeef31"
 
   url "https://download.sonatype.com/clm/scanner/nexus-iq-cli-#{version}-osx-#{pkg_name}.pkg"
 

--- a/Casks/nexus-iq-cli.rb
+++ b/Casks/nexus-iq-cli.rb
@@ -8,9 +8,9 @@ cask "nexus-iq-cli" do
   arch arm: "aarch64", intel: "x86_64"
   pkg_name = on_arch_conditional arm: "aarch_64", intel: "x86_64"
 
-  version "2.2.0-01"
-  sha256 arm:   "fakeSha256Arm",
-         intel: "fakeSha256Intel"
+  version "1.1.0-00"
+  sha256 arm:   "244bf5552da870634116c4b243f03b027de255bd6d91192335399f077fe4c9ce",
+         intel: "87587dfc303d317ec4d1af27f0c78f3829c56899bc765ea15aca2fc55eeeef31"
 
   url "https://download.sonatype.com/clm/scanner/nexus-iq-cli-#{version}-osx-#{pkg_name}.pkg"
 

--- a/Casks/nexus-iq-cli.rb
+++ b/Casks/nexus-iq-cli.rb
@@ -5,12 +5,12 @@
 #
 
 cask "nexus-iq-cli" do
-  arch arm: "aarch64", intel: "x86_64"
-  pkg_name = on_arch_conditional arm: "aarch_64", intel: "x86_64"
+  arch arm: "aarch64", intel: "fakeSha256Intel"
+  pkg_name = on_arch_conditional arm: "aarch_64", intel: "fakeSha256Intel"
 
   version "2.2.0-01"
-  sha256 arm:   "244bf5552da870634116c4b243f03b027de255bd6d91192335399f077fe4c9ce",
-         intel: "87587dfc303d317ec4d1af27f0c78f3829c56899bc765ea15aca2fc55eeeef31"
+  sha256 arm:   "fakeSha256Arm",
+         intel: "fakeSha256Intel"
 
   url "https://download.sonatype.com/clm/scanner/nexus-iq-cli-#{version}-osx-#{pkg_name}.pkg"
 

--- a/Casks/nexus-iq-cli.rb
+++ b/Casks/nexus-iq-cli.rb
@@ -8,7 +8,7 @@ cask "nexus-iq-cli" do
   arch arm: "aarch64", intel: "x86_64"
   pkg_name = on_arch_conditional arm: "aarch_64", intel: "x86_64"
 
-  version "2.2.0-01"
+  version "2.1.0-00"
   sha256 arm:   "244bf5552da870634116c4b243f03b027de255bd6d91192335399f077fe4c9ce",
          intel: "87587dfc303d317ec4d1af27f0c78f3829c56899bc765ea15aca2fc55eeeef31"
 

--- a/Casks/nexus-iq-cli.rb
+++ b/Casks/nexus-iq-cli.rb
@@ -8,9 +8,9 @@ cask "nexus-iq-cli" do
   arch arm: "aarch64", intel: "x86_64"
   pkg_name = on_arch_conditional arm: "aarch_64", intel: "x86_64"
 
-  version "2.1.0-00"
-  sha256 arm:   "244bf5552da870634116c4b243f03b027de255bd6d91192335399f077fe4c9ce",
-         intel: "87587dfc303d317ec4d1af27f0c78f3829c56899bc765ea15aca2fc55eeeef31"
+  version "2.2.0-01"
+  sha256 arm:   "fakeSha256Arm",
+         intel: "fakeSha256Intel"
 
   url "https://download.sonatype.com/clm/scanner/nexus-iq-cli-#{version}-osx-#{pkg_name}.pkg"
 

--- a/Casks/nexus-iq-cli.rb
+++ b/Casks/nexus-iq-cli.rb
@@ -16,7 +16,7 @@ cask "nexus-iq-cli" do
 
   name "Nexus Native IQ CLI"
   desc "Command line utility for application scanning with Nexus IQ"
-  homepage "https://help.sonatype.com/integrations/nexus-iq-cli"
+  homepage "https://links.sonatype.com/products/nxiq/doc/integrations/iq-cli"
   depends_on macos: ">= :mojave"
   pkg "nexus-iq-cli-#{version}-osx-#{pkg_name}.pkg"
   uninstall pkgutil: [

--- a/Casks/nexus-iq-cli.rb
+++ b/Casks/nexus-iq-cli.rb
@@ -8,9 +8,9 @@ cask "nexus-iq-cli" do
   arch arm: "aarch64", intel: "x86_64"
   pkg_name = on_arch_conditional arm: "aarch_64", intel: "x86_64"
 
-  version "1.1.0-00"
-  sha256 arm:   "244bf5552da870634116c4b243f03b027de255bd6d91192335399f077fe4c9ce",
-         intel: "87587dfc303d317ec4d1af27f0c78f3829c56899bc765ea15aca2fc55eeeef31"
+  version "2.2.0-01"
+  sha256 arm:   "fakeSha256Arm",
+         intel: "fakeSha256Intel"
 
   url "https://download.sonatype.com/clm/scanner/nexus-iq-cli-#{version}-osx-#{pkg_name}.pkg"
 

--- a/Casks/nexus-iq-cli.rb
+++ b/Casks/nexus-iq-cli.rb
@@ -9,8 +9,8 @@ cask "nexus-iq-cli" do
   pkg_name = on_arch_conditional arm: "aarch_64", intel: "x86_64"
 
   version "2.2.0-01"
-  sha256 arm:   "fakeSha256Arm",
-         intel: "fakeSha256Intel"
+  sha256 arm:   "244bf5552da870634116c4b243f03b027de255bd6d91192335399f077fe4c9ce",
+         intel: "87587dfc303d317ec4d1af27f0c78f3829c56899bc765ea15aca2fc55eeeef31"
 
   url "https://download.sonatype.com/clm/scanner/nexus-iq-cli-#{version}-osx-#{pkg_name}.pkg"
 

--- a/Casks/nexus-iq-cli.rb
+++ b/Casks/nexus-iq-cli.rb
@@ -5,14 +5,20 @@
 #
 
 cask "nexus-iq-cli" do
+  arch arm: "aarch64", intel: "x86_64"
+  pkg_name = on_arch_conditional arm: "aarch_64", intel: "x86_64"
+
   version "2.2.0-01"
-  sha256 "23cef70045bbb0c6d43842554248e7acc26ffcd7c17a0dfafc6c84db609e24f3"
-  url "https://download.sonatype.com/clm/scanner/nexus-iq-cli-2.2.0-01+944-mac.pkg"
+  sha256 arm:   "244bf5552da870634116c4b243f03b027de255bd6d91192335399f077fe4c9ce",
+         intel: "87587dfc303d317ec4d1af27f0c78f3829c56899bc765ea15aca2fc55eeeef31"
+
+  url "https://download.sonatype.com/clm/scanner/nexus-iq-cli-#{version}-osx-#{pkg_name}.pkg"
+
   name "Nexus Native IQ CLI"
   desc "Command line utility for application scanning with Nexus IQ"
   homepage "https://help.sonatype.com/integrations/nexus-iq-cli"
   depends_on macos: ">= :mojave"
-  pkg "nexus-iq-cli-2.2.0-01+944-mac.pkg"
+  pkg "nexus-iq-cli-#{version}-osx-#{pkg_name}.pkg"
   uninstall pkgutil: [
     "com.sonatype.nexus.iq.cli"
   ]

--- a/Casks/nexus-iq-cli.rb
+++ b/Casks/nexus-iq-cli.rb
@@ -8,8 +8,8 @@ cask "nexus-iq-cli" do
   arch arm: "aarch64", intel: "x86_64"
   pkg_name = on_arch_conditional arm: "aarch_64", intel: "x86_64"
 
-  version "1.1.0-00"
-  sha256 arm:   "244bf5552da870634116c4b243f03b027de255bd6d91192335399f077fe4c9ce",
+  version "2.2.0-01"
+  sha256 arm:   "fakeSha256Arm",
          intel: "87587dfc303d317ec4d1af27f0c78f3829c56899bc765ea15aca2fc55eeeef31"
 
   url "https://download.sonatype.com/clm/scanner/nexus-iq-cli-#{version}-osx-#{pkg_name}.pkg"


### PR DESCRIPTION
Relates to iq-cli PR: https://github.com/sonatype/iq-cli/pull/62

Once merged, this will "replace" the existing homebrew IQ CLI implementation, so we should wait until we are ready to do so.

NOTE: We should NOT merge this to the `main` branch until we are ready to release a new version of IQ-CLI with the new homebrew packages.

Jira: https://sonatype.atlassian.net/browse/INT-9043
Build: doesn't have a Jenkins CI build per-say. See builds, notes for related iq-cli PR above